### PR TITLE
feat(JSON排序): 实现JSON对象的深度排序功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-tools",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "author": "gausszhou",
   "scripts": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,7 +38,7 @@ export const tools: ITool[] = [
   },
   { label: 'JSON 压缩', value: EnumTools.JSON_COMPRESS, component: EditorDouble, order: 201 },
   { label: 'JSON 格式化', value: EnumTools.JSON_FORMAT, component: EditorDouble, order: 202 },
-  { label: 'JSON 排序', value: EnumTools.JSON_SORT, component: EditorDouble, order: 203 },
+  { label: 'JSON 深度排序', value: EnumTools.JSON_SORT, component: EditorDouble, order: 203 },
   { label: 'JSON 深度解析', value: EnumTools.JSON_PARSE_DEEP, component: EditorDouble, order: 204 },
   { label: 'JSON 嵌套转扁平', value: EnumTools.JSON_FLAT, component: EditorDouble, order: 205 },
   { label: 'JSON 扁平转嵌套', value: EnumTools.JSON_NESTING, component: EditorDouble, order: 206 },

--- a/src/transform/modules/json-sort.ts
+++ b/src/transform/modules/json-sort.ts
@@ -1,6 +1,6 @@
 function sortObject(obj: any) {
     return Object.keys(obj).sort().reduce(function (result: any, key) {
-        result[key] = obj[key];
+        result[key] = typeof obj[key] === 'object' ? sortObject(obj[key]) : obj[key];
         return result;
     }, {});
 }

--- a/src/views/EditorDouble.vue
+++ b/src/views/EditorDouble.vue
@@ -36,7 +36,18 @@ const codeJsonCompress = `{
 }`
 const codeJsonFormat = `{"foo":"bar","hello":"world"}`;
 const codeJsonParser = `{\"d\":\"{\\\"c\\\":\\\"{\\\\\\\"b\\\\\\\":\\\\\\\"{\\\\\\\\\\\\\\\"a\\\\\\\\\\\\\\\":1}\\\\\\\"}\\\"}\"}`;
-const codeJsonSort = `{"foo":"bar","hello":"world","a": 1, "d": 2, "c": 1}`;
+const codeJsonSort = `{
+  "foo": "bar",
+  "hello": "world",
+  "a": 1,
+  "d": 2,
+  "c": 1,
+  "b": {
+    "c": 3,
+    "b": 2,
+    "a": 1
+  }
+}`;
 const codeJson2Ts = `{
   "foo":"bar",
   "hello":"world",


### PR DESCRIPTION
修改json-sort.ts以支持嵌套对象的递归排序
更新示例数据展示深度排序效果
将功能标签从"JSON排序"改为"JSON深度排序"
更新版本号至1.0.9